### PR TITLE
994 adding create shipment route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor
 build
 .phpunit.result.cache
+/.idea

--- a/src/Exceptions/Models/Orders/OrderAlreadyShippedException.php
+++ b/src/Exceptions/Models/Orders/OrderAlreadyShippedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RackbeatSDK\Exceptions\Models\Orders;
+
+class OrderAlreadyShippedException extends \Exception
+{
+
+}

--- a/src/Exceptions/Models/Orders/OrderNotBookedException.php
+++ b/src/Exceptions/Models/Orders/OrderNotBookedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RackbeatSDK\Exceptions\Models\Orders;
+
+class OrderNotBookedException extends \Exception
+{
+
+}

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -62,17 +62,33 @@ class Order extends Model
 		return new OrderLineResource( $this->number );
 	}
 
-	public function book( $sendMail = false, $createShipment = false )
+	public function book( $sendMail = false )
 	{
 		if ( $this->is_booked ) {
 			throw new OrderAlreadyBookedException( 'The order ' . $this->number . ' is already booked.' );
 		}
 
 		$this->overrideDataFromModel(
-			( new OrderResource )->bookOrder( $this, $sendMail, $createShipment )
+			( new OrderResource )->bookOrder( $this, $sendMail )
 		);
 
 		return $this;
 	}
 
+    public function createShipment()
+    {
+        if ( !$this->is_booked ) {
+            throw new OrderNotBookedException( 'The order ' . $this->number . ' is not booked.' );
+        }
+
+        if ( $this->is_shipped ) {
+            throw new OrderAlreadyShippedException( 'The order ' . $this->number . ' has already been shipped' );
+        }
+
+        $this->overrideDataFromModel(
+            ( new OrderResource )->createShipmentForOrder( $this )
+        );
+
+        return $this;
+    }
 }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -85,9 +85,7 @@ class Order extends Model
             throw new OrderAlreadyShippedException( 'The order ' . $this->number . ' has already been shipped' );
         }
 
-        $this->overrideDataFromModel(
-            ( new OrderResource )->createShipmentForOrder( $this )
-        );
+        $test = ( new OrderResource )->createShipmentForOrder( $this );
 
         return $this;
     }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -3,6 +3,8 @@
 namespace RackbeatSDK\Models;
 
 use RackbeatSDK\Exceptions\Models\Orders\OrderAlreadyBookedException;
+use RackbeatSDK\Exceptions\Models\Orders\OrderAlreadyShippedException;
+use RackbeatSDK\Exceptions\Models\Orders\OrderNotBookedException;
 use RackbeatSDK\Models\Objects\AddressObject;
 use RackbeatSDK\Resources\OrderLineResource;
 use RackbeatSDK\Resources\OrderResource;
@@ -72,4 +74,21 @@ class Order extends Model
 
 		return $this;
 	}
+
+    public function createShipment()
+    {
+        if ( !$this->is_booked ) {
+            throw new OrderNotBookedException( 'The order ' . $this->number . ' is not booked.' );
+        }
+
+        if ( $this->is_shipped ) {
+            throw new OrderAlreadyShippedException( 'The order ' . $this->number . ' has already been shipped' );
+        }
+
+        $this->overrideDataFromModel(
+            ( new OrderResource )->createShipmentForOrder( $this )
+        );
+
+        return $this;
+    }
 }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -62,33 +62,17 @@ class Order extends Model
 		return new OrderLineResource( $this->number );
 	}
 
-	public function book( $sendMail = false )
+	public function book( $sendMail = false, $createShipment = false )
 	{
 		if ( $this->is_booked ) {
 			throw new OrderAlreadyBookedException( 'The order ' . $this->number . ' is already booked.' );
 		}
 
 		$this->overrideDataFromModel(
-			( new OrderResource )->bookOrder( $this, $sendMail )
+			( new OrderResource )->bookOrder( $this, $sendMail, $createShipment )
 		);
 
 		return $this;
 	}
 
-    public function createShipment()
-    {
-        if ( !$this->is_booked ) {
-            throw new OrderNotBookedException( 'The order ' . $this->number . ' is not booked.' );
-        }
-
-        if ( $this->is_shipped ) {
-            throw new OrderAlreadyShippedException( 'The order ' . $this->number . ' has already been shipped' );
-        }
-
-        $this->overrideDataFromModel(
-            ( new OrderResource )->createShipmentForOrder( $this )
-        );
-
-        return $this;
-    }
 }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -85,7 +85,7 @@ class Order extends Model
             throw new OrderAlreadyShippedException( 'The order ' . $this->number . ' has already been shipped' );
         }
 
-        $test = ( new OrderResource )->createShipmentForOrder( $this );
+        ( new OrderResource )->createShipmentForOrder( $this );
 
         return $this;
     }

--- a/src/Resources/OrderResource.php
+++ b/src/Resources/OrderResource.php
@@ -37,16 +37,26 @@ class OrderResource extends CrudResource
 		return $this->urlOverrides['book'] ?? ( trim( static::ENDPOINT_BASE, '/' ) . '/' . $number . '/book' );
 	}
 
-	public function bookOrder( Order $order, $sendMail, $createShipment )
+	public function bookOrder( Order $order, $sendMail )
 	{
-		return $this->requestWithSingleItemResponse( function ( $query ) use ( $order, $sendMail, $createShipment) {
+		return $this->requestWithSingleItemResponse( function ( $query ) use ( $order, $sendMail ) {
 			$query['mail'] = [
 				'send' => $sendMail
 			];
 
-            $query['create_shipment'] = $createShipment;
-
 			return API::http()->post( $this->getBookUrl( $order->number ), $query );
 		} );
 	}
+
+    public function getCreateShipmentUrl( $number ): string
+    {
+        return $this->urlOverrides['create_shipment'] ?? ( trim( static::ENDPOINT_BASE, '/' ) . '/' . $number . '/create-shipment' );
+    }
+
+    public function createShipmentForOrder( Order $order )
+    {
+        return $this->requestWithSingleItemResponse( function ( $query ) use ( $order ) {
+            return API::http()->post( $this->getCreateShipmentUrl( $order->number ), $query );
+        } );
+    }
 }

--- a/src/Resources/OrderResource.php
+++ b/src/Resources/OrderResource.php
@@ -55,7 +55,6 @@ class OrderResource extends CrudResource
 
     public function createShipmentForOrder( Order $order )
     {
-        $exp = API::http()->post( $this->getCreateShipmentUrl( $order->number ), []);
-        return $exp;
+        return API::http()->post( $this->getCreateShipmentUrl( $order->number ), []);
     }
 }

--- a/src/Resources/OrderResource.php
+++ b/src/Resources/OrderResource.php
@@ -47,4 +47,16 @@ class OrderResource extends CrudResource
 			return API::http()->post( $this->getBookUrl( $order->number ), $query );
 		} );
 	}
+
+    public function getCreateShipmentUrl( $number ): string
+    {
+        return $this->urlOverrides['create_shipment'] ?? ( trim( static::ENDPOINT_BASE, '/' ) . '/' . $number . '/create-shipment' );
+    }
+
+    public function createShipmentForOrder( Order $order )
+    {
+        return $this->requestWithSingleItemResponse( function ( $query ) use ( $order ) {
+            return API::http()->post( $this->getCreateShipmentUrl( $order->number ), $query );
+        } );
+    }
 }

--- a/src/Resources/OrderResource.php
+++ b/src/Resources/OrderResource.php
@@ -55,8 +55,7 @@ class OrderResource extends CrudResource
 
     public function createShipmentForOrder( Order $order )
     {
-        return $this->requestWithSingleItemResponse( function ( $query ) use ( $order ) {
-            return API::http()->post( $this->getCreateShipmentUrl( $order->number ), $query );
-        } );
+        $exp = API::http()->post( $this->getCreateShipmentUrl( $order->number ), []);
+        return $exp;
     }
 }

--- a/src/Resources/OrderResource.php
+++ b/src/Resources/OrderResource.php
@@ -37,26 +37,16 @@ class OrderResource extends CrudResource
 		return $this->urlOverrides['book'] ?? ( trim( static::ENDPOINT_BASE, '/' ) . '/' . $number . '/book' );
 	}
 
-	public function bookOrder( Order $order, $sendMail )
+	public function bookOrder( Order $order, $sendMail, $createShipment )
 	{
-		return $this->requestWithSingleItemResponse( function ( $query ) use ( $order, $sendMail ) {
+		return $this->requestWithSingleItemResponse( function ( $query ) use ( $order, $sendMail, $createShipment) {
 			$query['mail'] = [
 				'send' => $sendMail
 			];
 
+            $query['create_shipment'] = $createShipment;
+
 			return API::http()->post( $this->getBookUrl( $order->number ), $query );
 		} );
 	}
-
-    public function getCreateShipmentUrl( $number ): string
-    {
-        return $this->urlOverrides['create_shipment'] ?? ( trim( static::ENDPOINT_BASE, '/' ) . '/' . $number . '/create-shipment' );
-    }
-
-    public function createShipmentForOrder( Order $order )
-    {
-        return $this->requestWithSingleItemResponse( function ( $query ) use ( $order ) {
-            return API::http()->post( $this->getCreateShipmentUrl( $order->number ), $query );
-        } );
-    }
 }


### PR DESCRIPTION
Adds a new method to the order resource to create a shipment for the order. Related to the b2b task #994. 

Let me know if this makes sense. 

An awkward thing that happens here is that when the create_shipment route in rackbeat is called a OrderShipment resource is returned instead of an OrderResource so I'm a bit unsure of the way this is done here - this is also the reason the method has different logic from the booked method.

Also not sure how to add tests for new methods here - the preexisting tests seem just to test general functionality